### PR TITLE
Add meson buildsystem support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 ```
 
+Alternatively, meson can be used:
+
+```bash
+meson setup build
+ninja -C build
+```
+
 ### Running
 
 On **Linux** and **Windows**, you can run the engine by executing the `abyss` executable in the build directory.

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,34 @@
+project('AbyssEngine', 'c',
+    license: 'MIT',
+    default_options: [ 'buildtype=debugoptimized', 'c_std=c11', 'warning_level=1' ],
+    version: '0.0.1',
+    meson_version: '>=0.53.0',
+)
+
+conf = configuration_data()
+
+conf.set_quoted('PROJECT_NAME', meson.project_name())
+conf.set_quoted('PROJECT_VERSION_STRING', meson.project_version())
+
+version_split = meson.project_version().split('.')
+ver_major = version_split[0]
+ver_minor = version_split[1]
+ver_micro = version_split[2]
+
+conf.set('PROJECT_VERSION_MAJOR', ver_major)
+conf.set('PROJECT_VERSION_MINOR', ver_minor)
+conf.set('PROJECT_VERSION_MICRO', ver_micro)
+if host_machine.endian() == 'big'
+    conf.set('CONFIG_BIG_ENDIAN', 1)
+else
+    conf.set('CONFIG_BIG_ENDIAN', 0)
+endif
+
+cc = meson.get_compiler('c')
+
+subdir('src')
+
+configure_file(
+    output: 'config.h',
+    configuration: conf,
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,51 @@
+build_opts = [
+    '-D_ISOC11_SOURCE', '-D_XOPEN_SOURCE=700', '-U__STRICT_ANSI__',
+
+    # Warnings
+    '-Wundef', '-Wmissing-prototypes', '-Wshadow', '-Wparentheses',
+    '-Wpointer-arith', '-Wno-pointer-sign',
+
+    # Warnings to treat as errors
+    '-Werror=implicit-function-declaration',
+]
+
+# Required dependencies
+dependencies = [
+    dependency('zlib'),
+    dependency('sdl2'),
+]
+
+sources = [
+    'abyss.c',
+
+    'common/config.c',
+    'common/fileman.c',
+    'common/globals.c',
+    'common/log.c',
+    'common/mpq_stream.c',
+
+    'drawing/cursor.c',
+    'drawing/sprite.c',
+
+    'scenes/scene.c',
+    'scenes/scene_mainmenu.c',
+
+    'types/dc6.c',
+    'types/font.c',
+    'types/mpq.c',
+    'types/mpq_block.c',
+    'types/mpq_hash.c',
+    'types/mpq_header.c',
+    'types/palette.c',
+
+    'util/crypto.c',
+    'util/implode.c',
+]
+
+add_global_arguments(build_opts, language: 'c')
+
+executable('AbyssEngine',
+    install: true,
+    sources: sources,
+    dependencies: dependencies,
+)


### PR DESCRIPTION
Meson can automatically use in-tree versions of libraries by cloning them into a `submodules` folder, but I haven't documented that.